### PR TITLE
Balloons were missing a category 

### DIFF
--- a/GameData/KerBalloons/Parts/UniversalBalloon/universalPayload.cfg
+++ b/GameData/KerBalloons/Parts/UniversalBalloon/universalPayload.cfg
@@ -46,7 +46,7 @@ PART
 	TechRequired = start // engineering101
 	entryCost = 11000
 	cost = 550
-	category = none
+	category = Utility
 	subcategory = 0
 	title = KerBalloon (Kerbin) - Universal Balloon
 	manufacturer = KerBalloons


### PR DESCRIPTION
Therefore were not showing in the VAB and SPH in KSC. My mistake, it needed https://github.com/blowfishpro/B9PartSwitch/releases and it didn't load in properly